### PR TITLE
Remove newline char '%0D' from the session string

### DIFF
--- a/extension/uoc.js
+++ b/extension/uoc.js
@@ -857,7 +857,7 @@ var Session = new function() {
 		Debug.log(resp);
 		var matchs = resp.match(/campusSessionId = ([^\n]*)/);
 		if (matchs) {
-			var session = matchs[1];
+			var session = matchs[1].trim();
 			if (!get_working()) {
 				notify(_('__UOC_WORKING__'));
 			}


### PR DESCRIPTION
La expresión regular obtiene el string de sesión agregando un carácter invisible "%0D", lo que hacia que el request del timeline no retornara resultados "No results found", y por lo tanto, los eventos marcados con [status.activityProgress: "C"] no se detectaban.