### PR TITLE
La UOC a retirado el Google Capcha del login

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -34,7 +34,7 @@ var Start = new function() {
 			open_new_tab("changelog.html");
 			save_last_changelog(version);
 		}
-		// reset_session();
+		reset_session();
 		if (has_username_password()) {
 			check_messages(show_PAC_notifications);
 			return true;

--- a/extension/uoc.js
+++ b/extension/uoc.js
@@ -857,7 +857,7 @@ var Session = new function() {
 		Debug.log(resp);
 		var matchs = resp.match(/campusSessionId = ([^\n]*)/);
 		if (matchs) {
-			var session = matchs[1];
+			var session = matchs[1].trim();
 			if (!get_working()) {
 				notify(_('__UOC_WORKING__'));
 			}


### PR DESCRIPTION
Finalmente la UOC a retirado el Capcha del login, ahora la sesión se obtiene correctamente des de la petición POST, por lo tanto, se puede reiniciar la sesión en cada inicio para renovar la concesión.