### PR TITLE
Actualizaciones de estilo en el campus

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -34,7 +34,7 @@ var Start = new function() {
 			open_new_tab("changelog.html");
 			save_last_changelog(version);
 		}
-		// reset_session();
+		reset_session();
 		if (has_username_password()) {
 			check_messages(show_PAC_notifications);
 			return true;

--- a/extension/theme/styles.css
+++ b/extension/theme/styles.css
@@ -1,3 +1,31 @@
 body {
 }
  
+.main-column .flexbox-layout {
+    flex-direction: column!important;
+}
+.flexbox-layout div[class*=col-]:not(.hidden) {
+    width: 100%!important;
+}
+
+.marcadors .unic {
+    margin-right: 5px!important;
+}
+
+.modul {
+    border: 1px solid #ccc!important;
+    margin-bottom: 15px!important;
+}
+
+/* Hide Professor not tutor */
+.modul .widget__header--aula:not(.widget__header--tutorship) {
+    display: none!important;
+}
+
+.modul .modul__content, .toggleMenu {
+    display: none!important;
+}
+
+.modul.show_content .modul__content {
+    display: block!important;
+}

--- a/extension/theme/uoctheme.js
+++ b/extension/theme/uoctheme.js
@@ -34,17 +34,47 @@ function containerFluid(){
         }
 }
 
+function betterModulWidgets() {
+        var moduls = document.getElementsByClassName('modul');
+        for(var i = 0; i < moduls.length; i++) {
+                // Ensure show content to enable toggle click
+                var toggleMenuDisabled = moduls[i].querySelector('.toggleMenu .icon--arrow-down');
+                if (toggleMenuDisabled) {
+                        toggleMenuDisabled.parentElement.click();
+                }
+
+                var modulHeader = moduls[i].getElementsByClassName('modul__header')[0];
+                var modulContent = moduls[i].getElementsByClassName('modul__content')[0];
+                var modulMarcadors = moduls[i].getElementsByClassName('widget__marcadors')[0];
+                var modulNotification = modulContent.querySelector('.widget__marcadors .marcadors');
+
+                // Move notifications
+                if (modulNotification) {
+                        modulHeader.getElementsByClassName('modul__actions')[0].prepend(modulNotification);
+                        modulMarcadors.remove();
+                }
+
+                // Hide/show container
+                if (modulHeader.classList.contains('toggle_content_added')) continue;
+                modulHeader.classList.add('toggle_content_added');
+                modulHeader.addEventListener('click', function(e) {
+                        this.parentElement.classList.toggle('show_content');
+                });
+        }
+}
+
 chrome.runtime.sendMessage({uoctheme: "hello"}, function(response) {
-  if( response.active ){
+  if( response.active ) {
     var interval = setInterval(myTimer, 1000);
     var countInterval=0;
 
     function myTimer() {
-        if( ++countInterval > 5 ){
-	        stopTimer()
+        if(++countInterval > 5) {
+                stopTimer()
         }
-        removeNoticies();
-        containerFluid();
+        // removeNoticies();
+        // containerFluid();
+        betterModulWidgets();
     }
 
     function stopTimer() {

--- a/extension/uoc.js
+++ b/extension/uoc.js
@@ -857,7 +857,7 @@ var Session = new function() {
 		Debug.log(resp);
 		var matchs = resp.match(/campusSessionId = ([^\n]*)/);
 		if (matchs) {
-			var session = matchs[1];
+			var session = matchs[1].trim();
 			if (!get_working()) {
 				notify(_('__UOC_WORKING__'));
 			}

--- a/extension/uoc.js
+++ b/extension/uoc.js
@@ -338,7 +338,9 @@ function parse_classroom(classr) {
 			var resourcel = classr.widget.eines[j];
 			if (resourcel.nom) {
 				var resource = new Resource(resourcel.nom, resourcel.resourceId);
-				resource.set_link(resourcel.viewItemsUrl);
+				if( resourcel.viewItemsUrl ){
+					resource.set_link(resourcel.viewItemsUrl);
+				}
 				resource.set_pos(j);
 				resource = classroom.add_resource(resource);
 				retrieve_resource(classroom, resource);

--- a/extension/utils.js
+++ b/extension/utils.js
@@ -151,10 +151,10 @@ function empty_url_attr(url, attr) {
 function get_url_attr(url, attr){
     // closes #33
     if( !url ){
-        return false;
+        return '';
     }
     if(url.indexOf(attr) == -1){
-        return false;
+        return '';
     }
 
     var regexp = attr + "=([^&]+)";
@@ -163,7 +163,7 @@ function get_url_attr(url, attr){
     if (match) {
         return decodeURIComponent(match[1]);
     }
-    return false;
+    return '';
 }
 
 function addZero(i) {


### PR DESCRIPTION
Por lo general, mostrar el tema del campus con una versión más parecida a la de la extensión, para facilitar el ver las notificaciones.
(Las aulas se muestran/ocultan al igual que en la extensión, con un clic sobre el título)
![Screenshot_2](https://user-images.githubusercontent.com/79306683/134897615-1d7b2e46-c5c5-406d-9fa0-aa613d47d6d6.png)